### PR TITLE
Fetch synonyms in parallel with Promise.all and update state once

### DIFF
--- a/src/Components/main.js
+++ b/src/Components/main.js
@@ -21,47 +21,25 @@ class Main extends Component {
 
   input_blur=()=> {
     console.log('input_blur')
-    let self = this
 
-    let encoded_name = self.state.movie_name.split(' ');
-    let syns = [];
+    let encoded_name = this.state.movie_name.split(' ');
 
-    encoded_name.forEach(word => {
-      fetch("https://api.datamuse.com/words?ml="+word)
+    Promise.all(encoded_name.map(word => {
+      return fetch("https://api.datamuse.com/words?ml="+word)
         .then(res => res.json())
-        .then(
-          (result) => {
-            let res_words = result.slice(0, 5).map( resp => resp.word)
-
-
-            syns.push(res_words);
-
-            // console.log(syns)
-            // console.log(res_words)
-            // console.log(syns)
-
-            self.setState({"synonyms": syns})
-
-
-            // this.setState({
-            //   isLoaded: true,
-            //   items: result.items
-            // });
-          },
-          // Note: it's important to handle errors here
-          // instead of a catch() block so that we don't swallow
-          // exceptions from actual bugs in components.
-          (error) => {
-            // this.setState({
-            //   isLoaded: true,
-            //   error
-            // });
-          }
-        )
+        .then(result => result.slice(0, 5).map( resp => resp.word))
+    })).then(syns => {
+      this.setState({"synonyms": syns})
+    },
+    // Note: it's important to handle errors here
+    // instead of a catch() block so that we don't swallow
+    // exceptions from actual bugs in components.
+    (error) => {
+      // this.setState({
+      //   isLoaded: true,
+      //   error
+      // });
     })
-
-    // console.log(res_words);
-
   }
 
   input_change=(e)=> {


### PR DESCRIPTION
### Motivation

- Simplify and correct the asynchronous synonym lookup so per-word fetches run in parallel and the component state updates only after all results are ready.
- Remove unused variables and inline the mapping/processing of API results to make the code clearer and reduce intermediate mutation.

### Description

- Replaced a `forEach` of `fetch` calls and incremental `setState` updates with a single `Promise.all` over `encoded_name.map(...)` to fetch synonyms in parallel and aggregate results before updating state. 
- Transformed each fetch response into an array of the top 5 words via `.then(result => result.slice(0, 5).map(resp => resp.word))` and then `setState` once with the full `synonyms` array. 
- Removed the unused `self` variable and other commented/unused intermediate code paths to tighten the function body, while preserving the existing error handler comments.

### Testing

- Ran the test suite with `npm test` and existing unit tests passed. 
- Ran `npm run lint` to check formatting and code quality and the linter reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a510dcac178832fb27cd920ea87e5f3)