### PR TITLE
Polish movie game UI and add random movie generator

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -13,40 +13,232 @@
   src: url(./fonts/comicrelief_regular/ComicRelief-webfont.woff) format('woff');
 }
 
+:root {
+  color-scheme: dark;
+  --bg: #101828;
+  --card: rgba(255, 255, 255, 0.12);
+  --card-strong: rgba(255, 255, 255, 0.18);
+  --text: #fff8ee;
+  --muted: #bac7da;
+  --accent: #ff9f75;
+  --accent-strong: #ffcc66;
+  --shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
+}
 
+* {
+  box-sizing: border-box;
+}
 
 body {
-  /*font-family: Cartoonist;*/
-  font-family: ComicRelief;
-  background: #2f3d4c;
-  color: #fff;
-  font-size: 2em;
+  min-height: 100vh;
+  margin: 0;
+  font-family: ComicRelief, system-ui, sans-serif;
+  background:
+    radial-gradient(circle at top left, rgba(255, 159, 117, 0.28), transparent 32rem),
+    radial-gradient(circle at bottom right, rgba(93, 155, 255, 0.22), transparent 34rem),
+    linear-gradient(135deg, #172036 0%, #27364a 48%, #111827 100%);
+  color: var(--text);
+  font-size: 1.25rem;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: linear-gradient(to bottom, rgba(0,0,0,0.7), transparent);
 }
 
 h1, h2, h3, h4, h5{
-  font-family: Baloo;
-  color: #f28d79
+  margin: 0;
+  font-family: Baloo, ComicRelief, system-ui, sans-serif;
+  color: var(--accent);
+  line-height: 0.95;
 }
 
-.subtitle {
-  color: #96a3b5;
+button,
+input {
+  font: inherit;
 }
-
 
 input {
-  font-family: ComicRelief;
-  font-size: 1.25em;
-  background: transparent;
+  width: 100%;
+  min-width: 0;
+  padding: 0.85rem 1rem;
+  background: rgba(9, 16, 30, 0.72);
   outline: none;
-  border: 2px solid #fff;
-  border-radius: 15px;
-  color: #fff;
-  text-align: center;
-  max-width: 85%;
+  border: 2px solid rgba(255, 255, 255, 0.32);
+  border-radius: 18px;
+  color: var(--text);
+  box-shadow: inset 0 2px 8px rgba(0, 0, 0, 0.22);
+}
+
+input:focus {
+  border-color: var(--accent-strong);
+  box-shadow: 0 0 0 4px rgba(255, 204, 102, 0.18), inset 0 2px 8px rgba(0, 0, 0, 0.22);
+}
+
+button {
+  flex: 0 0 auto;
+  padding: 0.85rem 1.1rem;
+  border: 0;
+  border-radius: 18px;
+  color: #1d2635;
+  cursor: pointer;
+  background: linear-gradient(135deg, var(--accent-strong), var(--accent));
+  box-shadow: 0 12px 24px rgba(255, 159, 117, 0.28);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+button:hover,
+button:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(255, 159, 117, 0.38);
 }
 
 .App {
+  min-height: 100vh;
   text-align: center;
 }
 
-  
+.App-header {
+  min-height: 100vh;
+}
+
+.main-wrapper {
+  width: min(1080px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 4rem 0;
+}
+
+.hero-card,
+.clues-panel {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 36px;
+  background: var(--card);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.hero-card {
+  padding: clamp(2rem, 5vw, 4rem);
+}
+
+.hero-card::after {
+  content: '★';
+  position: absolute;
+  right: 2rem;
+  top: 1rem;
+  color: rgba(255, 204, 102, 0.3);
+  font-size: 7rem;
+  transform: rotate(12deg);
+}
+
+.eyebrow {
+  margin: 0 0 0.55rem;
+  color: var(--accent-strong);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+h1 {
+  font-size: clamp(3rem, 10vw, 6.5rem);
+}
+
+.lede,
+.subtitle,
+.empty-state {
+  color: var(--muted);
+}
+
+.lede {
+  max-width: 680px;
+  margin: 1rem auto 2rem;
+}
+
+.movie-form {
+  max-width: 760px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.movie-form label {
+  display: block;
+  margin: 0 0 0.5rem 0.25rem;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.input-row {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.subtitle {
+  margin: 1.5rem auto 0;
+  max-width: 760px;
+  font-size: 1rem;
+}
+
+.clues-panel {
+  margin-top: 1.5rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.section-heading {
+  margin-bottom: 1.5rem;
+}
+
+.section-heading h2 {
+  font-size: clamp(2rem, 6vw, 3.75rem);
+}
+
+.clue-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.clue-card,
+.empty-state {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  border-radius: 22px;
+  background: var(--card-strong);
+}
+
+.clue-card {
+  padding: 1rem;
+  color: #fff;
+}
+
+.empty-state {
+  margin: 0;
+  padding: 2rem;
+}
+
+@media (max-width: 640px) {
+  body {
+    font-size: 1rem;
+  }
+
+  .main-wrapper {
+    padding: 1rem 0;
+  }
+
+  .input-row {
+    flex-direction: column;
+  }
+
+  button {
+    width: 100%;
+  }
+}

--- a/src/Components/main.jsx
+++ b/src/Components/main.jsx
@@ -1,106 +1,152 @@
 import React, { Component } from 'react';
 
+const MOVIE_TITLES = [
+  'Blade Runner',
+  'The Grand Budapest Hotel',
+  'Moonlight',
+  'Spirited Away',
+  'The Matrix',
+  'Casablanca',
+  'Everything Everywhere All at Once',
+  'Mad Max Fury Road',
+  'The Princess Bride',
+  'Jurassic Park',
+  'The Social Network',
+  'Back to the Future',
+  'Pan\'s Labyrinth',
+  'Arrival',
+  'Knives Out',
+  'The Iron Giant',
+  'Hidden Figures',
+  'Ratatouille',
+  'No Country for Old Men',
+  'The Dark Knight',
+];
 
 class Main extends Component {
   constructor(props) {
     super(props)
-    this.state = { 
+    this.state = {
       movie_name: "Blade Runner",
       synonyms: [],
       synonyms_count: 5,
+      isLoading: false,
+      statusMessage: 'Type a movie title, pick a random one, then tab away to generate clue words.',
       skip_words: [
-        'in', 'on', 'of', 'where', 'when'
+        'in', 'on', 'of', 'where', 'when', 'the', 'a', 'an', 'for', 'to'
       ]
     }
   }
 
-  input_focus=()=> {
-    console.log('input_focus')
-    // this.setState({movie_name: ""})
-  }
+  generateSynonyms = (movieName = this.state.movie_name) => {
+    const encoded_name = movieName
+      .split(' ')
+      .map(word => word.trim())
+      .filter(Boolean);
 
-  input_blur=()=> {
-    console.log('input_blur')
+    if (encoded_name.length === 0) {
+      this.setState({ synonyms: [], statusMessage: 'Add a movie title to get clue words.' });
+      return;
+    }
 
-    let encoded_name = this.state.movie_name.split(' ');
+    this.setState({ isLoading: true, statusMessage: 'Generating clue words...' });
 
     Promise.all(encoded_name.map(word => {
-      return fetch("https://api.datamuse.com/words?ml="+word)
+      if (this.state.skip_words.includes(word.toLowerCase())) {
+        return Promise.resolve([word]);
+      }
+
+      return fetch(`https://api.datamuse.com/words?ml=${encodeURIComponent(word)}`)
         .then(res => res.json())
-        .then(result => result.slice(0, 5).map( resp => resp.word))
+        .then(result => {
+          const matches = result.slice(0, this.state.synonyms_count).map(resp => resp.word);
+          return matches.length ? matches : [word];
+        });
     })).then(syns => {
-      this.setState({"synonyms": syns})
-    },
-    // Note: it's important to handle errors here
-    // instead of a catch() block so that we don't swallow
-    // exceptions from actual bugs in components.
-    (error) => {
-      // this.setState({
-      //   isLoaded: true,
-      //   error
-      // });
+      this.setState({
+        synonyms: syns,
+        isLoading: false,
+        statusMessage: 'Use these clue rows to help players guess the real movie title.'
+      });
+    }, () => {
+      this.setState({
+        synonyms: [],
+        isLoading: false,
+        statusMessage: 'Could not reach the clue-word service. Try again in a moment.'
+      });
     })
   }
 
-  input_change=(e)=> {
-    // console.log('input_change', e)
-    this.setState({movie_name: e.target.value})
+  input_blur=()=> {
+    this.generateSynonyms();
   }
 
+  input_change=(e)=> {
+    this.setState({movie_name: e.target.value, synonyms: []})
+  }
+
+  randomizeMovie=()=> {
+    const availableTitles = MOVIE_TITLES.filter(title => title !== this.state.movie_name);
+    const randomTitle = availableTitles[Math.floor(Math.random() * availableTitles.length)] || MOVIE_TITLES[0];
+    this.setState({ movie_name: randomTitle, synonyms: [] }, () => this.generateSynonyms(randomTitle));
+  }
 
   render() {
-    let {synonyms, movie_name, synonyms_count} = this.state;
+    let {synonyms, movie_name, synonyms_count, isLoading, statusMessage} = this.state;
 
-    let syn_list = '';
+    let syn_list = null;
+    const words = movie_name.split(' ').filter(Boolean);
 
-    if(synonyms.length === movie_name.split(" ").length ) {
-      let built_words = []
-      // console.log(synonyms)
-      for (var i = 0; i <= synonyms_count - 1; i++) {
-        // built_words[i] = synonyms[0][i]+" | "+synonyms[1][i];
+    if(synonyms.length === words.length ) {
+      const built_words = [];
 
+      for (let i = 0; i <= synonyms_count - 1; i++) {
+        const rowWords = [];
 
-        built_words[i] = '';
-        for (var s = 0; s <= synonyms.length - 1; s++) {
-          // console.log(synonyms[s][i])
-          built_words[i] += synonyms[s][i]
-          if(s !==  synonyms.length - 1) 
-            built_words[i] += " | ";
+        for (let s = 0; s <= synonyms.length - 1; s++) {
+          rowWords.push(synonyms[s][i] || synonyms[s][0] || words[s]);
         }
 
+        built_words[i] = rowWords.join(' · ');
       }
 
-      syn_list = built_words.map(word => {
-        // console.log(word);
-        return (
-          <p>{word}</p>
-        )
-      })
-
+      syn_list = built_words.map((word, index) => (
+        <li className="clue-card" key={`${word}-${index}`}>{word}</li>
+      ));
     }
 
-
     return (
-      <div className="main-wrapper">
-        <h2> Movie Name </h2>
-        <input type="text" 
-          name="movie_name" 
-          value={this.state.movie_name} 
-          onFocus={this.input_focus} 
-          onBlur={this.input_blur}
-          onChange={e => {this.input_change(e)}}
-        />
+      <main className="main-wrapper">
+        <section className="hero-card" aria-labelledby="movie-name-heading">
+          <p className="eyebrow">Movie clue party game</p>
+          <h1 id="movie-name-heading">Movie Name Remix</h1>
+          <p className="lede">Turn famous titles into playful synonym clues for a fast guessing round.</p>
 
-        <p className="subtitle">Play Words:</p>
-        {/*<p>Knife Sprinter</p>
-        <p>Sword Dasher</p>
-        <p>Metal Rusher</p>
-        <p>--------------</p>
-      */}
-        
-        {syn_list}
+          <div className="movie-form">
+            <label htmlFor="movie-name">Movie title</label>
+            <div className="input-row">
+              <input type="text"
+                id="movie-name"
+                name="movie_name"
+                value={this.state.movie_name}
+                onBlur={this.input_blur}
+                onChange={e => {this.input_change(e)}}
+              />
+              <button type="button" onClick={this.randomizeMovie}>Random movie</button>
+            </div>
+          </div>
 
-      </div>
+          <p className="subtitle" role="status">{isLoading ? '🎬 ' : '✨ '}{statusMessage}</p>
+        </section>
+
+        <section className="clues-panel" aria-labelledby="clues-heading">
+          <div className="section-heading">
+            <p className="eyebrow">Play words</p>
+            <h2 id="clues-heading">Clue board</h2>
+          </div>
+          {syn_list ? <ul className="clue-list">{syn_list}</ul> : <p className="empty-state">Your generated clues will appear here.</p>}
+        </section>
+      </main>
     )
   }
 }


### PR DESCRIPTION
### Motivation
- Improve the app appearance and UX so the clue-generation game looks polished and is easier to use on desktop and mobile.
- Provide a convenient way to pick a movie title automatically so users can quickly generate clue rows without typing.

### Description
- Implemented a refreshed dark glass-card layout, responsive spacing, gradients, and new typography/controls in `src/App.css` using CSS variables and media queries. 
- Replaced the simple input layout with a hero card, improved input and button styling, and added a responsive clue-board grid and empty state styles in `src/App.css`.
- Added a curated `MOVIE_TITLES` list and a `randomizeMovie` action in `src/Components/main.jsx` that sets a random title and triggers synonym generation. 
- Reworked clue generation in `src/Components/main.jsx` to skip common filler words, request synonyms from Datamuse with encoded queries, show loading/status messages, and provide fallbacks when no synonyms are returned.

### Testing
- Ran `git diff --check` which reported no whitespace or merge issues. 
- Attempted `npm test -- --runInBand` but the test runner could not run because `vitest` is not available in the current environment. 
- Attempted `npm run build` but the build step could not run because `vite` is not available in the current environment. 
- Attempted `npm install` to install missing dev dependencies but the install failed due to a `403 Forbidden` response from the registry for `@vitejs/plugin-react`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51f8da3bb4832fb2a2453d88bf1bec)