### PR TITLE
Refine scoring and timer game flow

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -144,6 +144,28 @@ button:disabled {
   font-size: 1.85rem;
 }
 
+.top-status {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+
+.turn-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2.4rem;
+  padding: 0.35rem 0.65rem;
+  border: 1px solid rgba(255, 204, 102, 0.34);
+  border-radius: 999px;
+  color: var(--accent-strong);
+  background: rgba(255, 204, 102, 0.12);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .hero-card,
 .clues-panel,
 .timer-card,
@@ -228,7 +250,18 @@ button:disabled {
   justify-content: flex-end;
 }
 
-.clues-panel {
+.timer-controls {
+  display: grid;
+  gap: 0.55rem;
+  justify-items: end;
+}
+
+.add-point-button {
+  width: 100%;
+}
+
+.clues-panel,
+.timer-card {
   margin-top: 0.65rem;
 }
 
@@ -354,6 +387,12 @@ button:disabled {
   padding-inline: 0.75rem;
 }
 
+.score-toggle {
+  min-width: 4.4rem;
+  font-family: Baloo, ComicRelief, system-ui, sans-serif;
+  font-size: 1.2rem;
+}
+
 @media (max-width: 430px) {
   .input-row {
     grid-template-columns: 1fr 1fr;
@@ -372,8 +411,13 @@ button:disabled {
     justify-content: stretch;
   }
 
-  .timer-actions button {
+  .timer-actions button,
+  .add-point-button {
     flex: 1 1 auto;
+  }
+
+  .timer-controls {
+    justify-items: stretch;
   }
 }
 

--- a/src/Components/main.jsx
+++ b/src/Components/main.jsx
@@ -21,6 +21,35 @@ const MOVIE_TITLES = [
   'Ratatouille',
   'No Country for Old Men',
   'The Dark Knight',
+  'Oppenheimer',
+  'Barbie',
+  'Dune Part Two',
+  'Inside Out 2',
+  'Deadpool and Wolverine',
+  'Wicked',
+  'The Substance',
+  'Anora',
+  'Challengers',
+  'Godzilla Minus One',
+  'Past Lives',
+  'Poor Things',
+  'The Holdovers',
+  'Killers of the Flower Moon',
+  'Top Gun Maverick',
+  'Spider Man Across the Spider Verse',
+  'Avatar The Way of Water',
+  'The Batman',
+  'A Quiet Place Day One',
+  'Kingdom of the Planet of the Apes',
+  'Furiosa A Mad Max Saga',
+  'The Fall Guy',
+  'Civil War',
+  'Longlegs',
+  'The Wild Robot',
+  'Flow',
+  'Conclave',
+  'Nosferatu',
+  'Alien Romulus',
 ];
 
 class Main extends Component {
@@ -31,14 +60,14 @@ class Main extends Component {
       synonyms: [],
       synonyms_count: 5,
       isLoading: false,
-      statusMessage: 'Type a movie title. Clues search after each space, or tap Search.',
+      statusMessage: 'Type a movie title, then press Enter or tap Search.',
       teams: [
         { name: 'Team One', score: 0 },
         { name: 'Team Two', score: 0 },
       ],
       activeTeam: 0,
-      roundSeconds: 60,
-      secondsRemaining: 60,
+      roundSeconds: 120,
+      secondsRemaining: 120,
       isTimerRunning: false,
       isScorePopupOpen: false,
       skip_words: [
@@ -92,19 +121,16 @@ class Main extends Component {
     })
   }
 
-  input_blur=()=> {
-    this.generateSynonyms();
-  }
-
   input_change=(e)=> {
     const nextMovieName = e.target.value;
-    const shouldSearchOnSpace = /\s$/.test(nextMovieName) && nextMovieName.trim().length > 0;
+    this.setState({movie_name: nextMovieName, synonyms: []})
+  }
 
-    this.setState({movie_name: nextMovieName, synonyms: []}, () => {
-      if (shouldSearchOnSpace) {
-        this.generateSynonyms(nextMovieName);
-      }
-    })
+  input_key_down=(e)=> {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      this.generateSynonyms();
+    }
   }
 
   startTimer=()=> {
@@ -144,8 +170,9 @@ class Main extends Component {
     this.setState(({ activeTeam, teams }) => ({ activeTeam: (activeTeam + 1) % teams.length }));
   }
 
-  updateScore=(teamIndex, amount)=> {
-    this.setState(({ teams }) => ({
+  updateScore=(teamIndex, amount, closePopup = false)=> {
+    this.setState(({ teams, isScorePopupOpen }) => ({
+      isScorePopupOpen: closePopup ? false : isScorePopupOpen,
       teams: teams.map((team, index) => {
         if (index !== teamIndex) {
           return team;
@@ -156,21 +183,43 @@ class Main extends Component {
     }));
   }
 
-  resetScores=()=> {
-    this.setState(({ teams }) => ({
+  resetScores=(closePopup = false)=> {
+    this.setState(({ teams, isScorePopupOpen }) => ({
       activeTeam: 0,
+      isScorePopupOpen: closePopup ? false : isScorePopupOpen,
       teams: teams.map(team => ({ ...team, score: 0 }))
     }));
   }
 
-  passTurn=()=> {
-    this.switchTeam();
-    this.resetTimer();
+  passTurn=(closePopup = false)=> {
+    if (this.timerId) {
+      window.clearInterval(this.timerId);
+      this.timerId = null;
+    }
+
+    this.setState(({ activeTeam, teams, roundSeconds, isScorePopupOpen }) => ({
+      activeTeam: (activeTeam + 1) % teams.length,
+      secondsRemaining: roundSeconds,
+      isTimerRunning: false,
+      isScorePopupOpen: closePopup ? false : isScorePopupOpen,
+    }));
   }
 
-  awardPoint=()=> {
-    this.updateScore(this.state.activeTeam, 1);
-    this.passTurn();
+  awardPoint=(closePopup = false)=> {
+    if (this.timerId) {
+      window.clearInterval(this.timerId);
+      this.timerId = null;
+    }
+
+    this.setState(({ activeTeam, teams, roundSeconds, isScorePopupOpen }) => ({
+      activeTeam: (activeTeam + 1) % teams.length,
+      secondsRemaining: roundSeconds,
+      isTimerRunning: false,
+      isScorePopupOpen: closePopup ? false : isScorePopupOpen,
+      teams: teams.map((team, index) => (
+        index === activeTeam ? { ...team, score: team.score + 1 } : team
+      )),
+    }));
   }
 
   openScorePopup=()=> {
@@ -205,15 +254,15 @@ class Main extends Component {
             <h2>{team.name}</h2>
             <p className="score">{team.score}</p>
             <div className="score-actions">
-              <button type="button" className="secondary-button" onClick={() => this.updateScore(index, -1)}>-</button>
-              <button type="button" className="secondary-button" onClick={() => this.updateScore(index, 1)}>+</button>
+              <button type="button" className="secondary-button" onClick={() => this.updateScore(index, -1, true)}>-</button>
+              <button type="button" className="secondary-button" onClick={() => this.updateScore(index, 1, true)}>+</button>
             </div>
           </article>
         ))}
         <div className="round-actions score-round-actions">
-          <button type="button" onClick={this.awardPoint}>Correct + switch</button>
-          <button type="button" className="secondary-button" onClick={this.passTurn}>Pass turn</button>
-          <button type="button" className="secondary-button" onClick={this.resetScores}>Reset scores</button>
+          <button type="button" onClick={() => this.awardPoint(true)}>Add point</button>
+          <button type="button" className="secondary-button" onClick={() => this.passTurn(true)}>Skip</button>
+          <button type="button" className="secondary-button" onClick={() => this.resetScores(true)}>Reset scores</button>
         </div>
       </div>
     );
@@ -250,7 +299,10 @@ class Main extends Component {
             <p className="eyebrow">Movie clue party game</p>
             <h1 id="movie-name-heading">Remix</h1>
           </div>
-          <button type="button" className="secondary-button score-toggle" onClick={this.openScorePopup}>Scores</button>
+          <div className="top-status" aria-label="Game status">
+            <span className="turn-pill">Turn {activeTeam + 1}</span>
+            <button type="button" className="secondary-button score-toggle" onClick={this.openScorePopup}>{teams.map(team => team.score).join(' - ')}</button>
+          </div>
         </header>
 
         <section className="hero-card" aria-labelledby="movie-name-heading">
@@ -261,8 +313,8 @@ class Main extends Component {
                 id="movie-name"
                 name="movie_name"
                 value={this.state.movie_name}
-                onBlur={this.input_blur}
                 onChange={e => {this.input_change(e)}}
+                onKeyDown={this.input_key_down}
               />
               <button type="button" onClick={() => this.generateSynonyms()} disabled={isLoading}>Search</button>
               <button type="button" className="secondary-button" onClick={this.randomizeMovie}>Random</button>
@@ -272,24 +324,27 @@ class Main extends Component {
           <p className="subtitle" role="status">{isLoading ? '🎬 ' : '✨ '}{statusMessage}</p>
         </section>
 
-        <section className="timer-card compact-timer" aria-label="Round timer">
-          <div>
-            <p className="eyebrow">{teams[activeTeam].name} guessing</p>
-            <p className="timer-display" aria-live="polite">{this.formatTime()}</p>
-          </div>
-          <div className="timer-actions">
-            <button type="button" onClick={this.startTimer} disabled={isTimerRunning || secondsRemaining === 0}>Start</button>
-            <button type="button" className="secondary-button" onClick={this.stopTimer} disabled={!isTimerRunning}>Pause</button>
-            <button type="button" className="secondary-button" onClick={this.resetTimer}>Reset</button>
-          </div>
-        </section>
-
         <section className="clues-panel" aria-labelledby="clues-heading">
           <div className="section-heading">
             <p className="eyebrow">Play words</p>
             <h2 id="clues-heading">Clues</h2>
           </div>
           {syn_list ? <ul className="clue-list">{syn_list}</ul> : <p className="empty-state">Your generated clues will appear here.</p>}
+        </section>
+
+        <section className="timer-card compact-timer" aria-label="Round timer">
+          <div>
+            <p className="eyebrow">{teams[activeTeam].name} guessing</p>
+            <p className="timer-display" aria-live="polite">{this.formatTime()}</p>
+          </div>
+          <div className="timer-controls">
+            <div className="timer-actions">
+              <button type="button" onClick={this.startTimer} disabled={isTimerRunning || secondsRemaining === 0}>Start</button>
+              <button type="button" className="secondary-button" onClick={this.stopTimer} disabled={!isTimerRunning}>Pause</button>
+              <button type="button" className="secondary-button" onClick={this.resetTimer}>Reset</button>
+            </div>
+            <button type="button" className="add-point-button" onClick={() => this.awardPoint()}>Add point</button>
+          </div>
         </section>
 
         {isScorePopupOpen && (


### PR DESCRIPTION
### Motivation

- Surface a compact turn indicator and show the live numeric score on the top-bar so players can quickly see the turn and scores.  
- Make clue-search explicit (Enter / Search) rather than auto-searching on spaces/blur to reduce accidental lookups.  
- Move and extend the round timer to two minutes and expose an easy Add point control near the timer.  
- Improve scoring flow by renaming actions to `Add point` / `Skip` and closing the score popup whenever a scoring action is taken.

### Description

- Expanded the movie pool in `src/Components/main.jsx` with many recent/trending (including multi-word) titles for the randomizer.  
- Changed input handling so typing no longer triggers searches on space/blur and added an `onKeyDown` handler to trigger `generateSynonyms()` on Enter, and updated the status message accordingly.  
- Increased round length by setting `roundSeconds` / `secondsRemaining` to `120` and moved the timer UI below the clues; added an `Add point` button next to the timer controls and stopped the timer when awarding/skipping.  
- Reworked scoring functions to accept a `closePopup` flag and updated `updateScore`, `resetScores`, `passTurn`, and `awardPoint` to close the score modal when invoked from the popup; renamed scoring buttons to `Add point` and `Skip` and updated the score popup button to display live scores (e.g. `1 - 2`).  
- Updated `src/App.css` to add `.top-status`, `.turn-pill`, `.timer-controls`, `.add-point-button`, and responsive tweaks so the new top-bar and timer controls render correctly.

### Testing

- Ran the test suite with `npm test` which passed (1 test file, 1 test).  
- Built the production bundle with `npm run build` which completed successfully.  
- An attempted run `npm test -- --runInBand` failed because Vitest does not support the Jest `--runInBand` flag, so the plain `npm test` result above is used.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a527328826c832fac91e4279defe601)