### PR TITLE
Deploy on master, random initial movie, input submit/blur/clear, and Skip button

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - main
+      - master
   workflow_dispatch:
 
 permissions:

--- a/src/App.css
+++ b/src/App.css
@@ -256,7 +256,15 @@ button:disabled {
   justify-items: end;
 }
 
-.add-point-button {
+.turn-result-actions {
+  display: grid;
+  width: 100%;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.45rem;
+}
+
+.add-point-button,
+.skip-button {
   width: 100%;
 }
 
@@ -412,7 +420,8 @@ button:disabled {
   }
 
   .timer-actions button,
-  .add-point-button {
+  .add-point-button,
+  .skip-button {
     flex: 1 1 auto;
   }
 

--- a/src/Components/main.jsx
+++ b/src/Components/main.jsx
@@ -52,12 +52,18 @@ const MOVIE_TITLES = [
   'Alien Romulus',
 ];
 
+const getRandomMovieTitle = (excludedTitle = '') => {
+  const availableTitles = MOVIE_TITLES.filter(title => title !== excludedTitle);
+  return availableTitles[Math.floor(Math.random() * availableTitles.length)] || MOVIE_TITLES[0];
+}
+
 class Main extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      movie_name: "Blade Runner",
+      movie_name: getRandomMovieTitle(),
       synonyms: [],
+      clueMovieName: '',
       synonyms_count: 5,
       isLoading: false,
       statusMessage: 'Type a movie title, then press Enter or tap Search.',
@@ -93,7 +99,7 @@ class Main extends Component {
       return;
     }
 
-    this.setState({ isLoading: true, statusMessage: 'Generating clue words...' });
+    this.setState({ isLoading: true, clueMovieName: movieName, statusMessage: 'Generating clue words...' });
 
     Promise.all(encoded_name.map(word => {
       if (this.state.skip_words.includes(word.toLowerCase())) {
@@ -126,10 +132,16 @@ class Main extends Component {
     this.setState({movie_name: nextMovieName, synonyms: []})
   }
 
+  submitMovieTitle=(movieName = this.state.movie_name)=> {
+    this.generateSynonyms(movieName);
+    this.setState({ movie_name: '' });
+  }
+
   input_key_down=(e)=> {
     if (e.key === 'Enter') {
       e.preventDefault();
-      this.generateSynonyms();
+      e.currentTarget.blur();
+      this.submitMovieTitle(e.currentTarget.value);
     }
   }
 
@@ -231,8 +243,7 @@ class Main extends Component {
   }
 
   randomizeMovie=()=> {
-    const availableTitles = MOVIE_TITLES.filter(title => title !== this.state.movie_name);
-    const randomTitle = availableTitles[Math.floor(Math.random() * availableTitles.length)] || MOVIE_TITLES[0];
+    const randomTitle = getRandomMovieTitle(this.state.movie_name);
     this.setState({ movie_name: randomTitle, synonyms: [] }, () => this.generateSynonyms(randomTitle));
   }
 
@@ -269,10 +280,10 @@ class Main extends Component {
   }
 
   render() {
-    let {synonyms, movie_name, synonyms_count, isLoading, statusMessage, teams, activeTeam, isTimerRunning, secondsRemaining, isScorePopupOpen} = this.state;
+    let {synonyms, movie_name, clueMovieName, synonyms_count, isLoading, statusMessage, teams, activeTeam, isTimerRunning, secondsRemaining, isScorePopupOpen} = this.state;
 
     let syn_list = null;
-    const words = movie_name.split(' ').filter(Boolean);
+    const words = (clueMovieName || movie_name).split(' ').filter(Boolean);
 
     if(synonyms.length === words.length ) {
       const built_words = [];
@@ -316,7 +327,7 @@ class Main extends Component {
                 onChange={e => {this.input_change(e)}}
                 onKeyDown={this.input_key_down}
               />
-              <button type="button" onClick={() => this.generateSynonyms()} disabled={isLoading}>Search</button>
+              <button type="button" onClick={() => this.submitMovieTitle()} disabled={isLoading}>Search</button>
               <button type="button" className="secondary-button" onClick={this.randomizeMovie}>Random</button>
             </div>
           </div>
@@ -343,7 +354,10 @@ class Main extends Component {
               <button type="button" className="secondary-button" onClick={this.stopTimer} disabled={!isTimerRunning}>Pause</button>
               <button type="button" className="secondary-button" onClick={this.resetTimer}>Reset</button>
             </div>
-            <button type="button" className="add-point-button" onClick={() => this.awardPoint()}>Add point</button>
+            <div className="turn-result-actions">
+              <button type="button" className="add-point-button" onClick={() => this.awardPoint()}>Add point</button>
+              <button type="button" className="secondary-button skip-button" onClick={() => this.passTurn()}>Skip</button>
+            </div>
           </div>
         </section>
 


### PR DESCRIPTION
### Motivation

- Enable automatic deployment from the repository's `master` branch instead of `main` for GitHub Pages.
- Avoid using a single hard-coded default movie and instead pick an initial title from the configured list to diversify gameplay.
- Improve mobile/keyboard UX by closing the keyboard on Enter and clearing the input after submission, and provide an in-round Skip action alongside Add point.

### Description

- Change the GitHub Pages workflow trigger branch from `main` to `master` in `.github/workflows/deploy-pages.yml` so pushes to `master` trigger build/deploy.
- Replace the hard-coded default `movie_name` with a `getRandomMovieTitle` helper and set the initial `movie_name` to `getRandomMovieTitle()` in `src/Components/main.jsx`.
- Introduce `clueMovieName` state and set it when generating clues so the generated clue rows keep using the submitted title while clearing the input field for the user.
- Add `submitMovieTitle` handler, call `e.currentTarget.blur()` on Enter to close keyboards, clear the input with `this.setState({ movie_name: '' })`, and wire the `Search` button to `submitMovieTitle` in `src/Components/main.jsx`.
- Add a `Skip` button next to the `Add point` button and create `.turn-result-actions` and `.skip-button` styles in `src/App.css` to support the two-button layout and responsive behavior.

### Testing

- Running `npm test -- --runInBand` failed because Vitest does not accept the Jest-specific `--runInBand` option.
- Running `npm test` succeeded with the single smoke test passing (`1 passed`).
- Running `npm run build` succeeded and produced a production build via Vite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52893140e4832f9570725dd41d0001)