### PR TITLE
Improve team header and clue UX

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -275,7 +275,7 @@ button:disabled {
 
 .section-heading {
   display: flex;
-  align-items: baseline;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 0.75rem;
   margin-bottom: 0.7rem;
@@ -284,6 +284,33 @@ button:disabled {
 
 .section-heading h2 {
   font-size: 1.75rem;
+}
+
+.clue-title {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  text-align: right;
+}
+
+.clue-title strong {
+  color: var(--accent-strong);
+}
+
+.source-words {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-bottom: 0.7rem;
+}
+
+.source-words span {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid rgba(255, 204, 102, 0.28);
+  border-radius: 999px;
+  color: var(--accent-strong);
+  background: rgba(255, 204, 102, 0.1);
+  font-size: 0.8rem;
 }
 
 .clue-list {
@@ -296,11 +323,31 @@ button:disabled {
 }
 
 .clue-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.65rem;
   padding: 0.8rem;
   border: 1px solid rgba(255, 255, 255, 0.16);
   border-radius: 18px;
   background: var(--card-strong);
   color: #fff;
+  text-align: left;
+}
+
+.clue-number {
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  color: #1d2635;
+  background: var(--accent-strong);
+  font-family: Baloo, ComicRelief, system-ui, sans-serif;
+  font-size: 0.78rem;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.clue-phrase {
+  overflow-wrap: anywhere;
 }
 
 .empty-state {

--- a/src/Components/main.jsx
+++ b/src/Components/main.jsx
@@ -95,7 +95,7 @@ class Main extends Component {
       .filter(Boolean);
 
     if (encoded_name.length === 0) {
-      this.setState({ synonyms: [], statusMessage: 'Add a movie title to get clue words.' });
+      this.setState({ synonyms: [], clueMovieName: '', statusMessage: 'Add a movie title to get clue words.' });
       return;
     }
 
@@ -129,11 +129,25 @@ class Main extends Component {
 
   input_change=(e)=> {
     const nextMovieName = e.target.value;
-    this.setState({movie_name: nextMovieName, synonyms: []})
+    this.setState({
+      movie_name: nextMovieName,
+      clueMovieName: '',
+      synonyms: [],
+      statusMessage: nextMovieName.trim()
+        ? 'Press Enter or Search to generate clue words for this title.'
+        : 'Type a movie title, then press Enter or tap Search.',
+    })
   }
 
   submitMovieTitle=(movieName = this.state.movie_name)=> {
-    this.generateSynonyms(movieName);
+    const submittedMovieName = movieName.trim();
+
+    if (!submittedMovieName) {
+      this.setState({ synonyms: [], clueMovieName: '', statusMessage: 'Add a movie title to get clue words.' });
+      return;
+    }
+
+    this.generateSynonyms(submittedMovieName);
     this.setState({ movie_name: '' });
   }
 
@@ -243,8 +257,8 @@ class Main extends Component {
   }
 
   randomizeMovie=()=> {
-    const randomTitle = getRandomMovieTitle(this.state.movie_name);
-    this.setState({ movie_name: randomTitle, synonyms: [] }, () => this.generateSynonyms(randomTitle));
+    const randomTitle = getRandomMovieTitle(this.state.movie_name || this.state.clueMovieName);
+    this.setState({ movie_name: randomTitle, clueMovieName: '', synonyms: [] }, () => this.generateSynonyms(randomTitle));
   }
 
   formatTime = () => {
@@ -281,6 +295,7 @@ class Main extends Component {
 
   render() {
     let {synonyms, movie_name, clueMovieName, synonyms_count, isLoading, statusMessage, teams, activeTeam, isTimerRunning, secondsRemaining, isScorePopupOpen} = this.state;
+    const activeTeamName = teams[activeTeam].name;
 
     let syn_list = null;
     const words = (clueMovieName || movie_name).split(' ').filter(Boolean);
@@ -299,7 +314,10 @@ class Main extends Component {
       }
 
       syn_list = built_words.map((word, index) => (
-        <li className="clue-card" key={`${word}-${index}`}>{word}</li>
+        <li className="clue-card" key={`${word}-${index}`}>
+          <span className="clue-number">Set {index + 1}</span>
+          <span className="clue-phrase">{word}</span>
+        </li>
       ));
     }
 
@@ -311,7 +329,7 @@ class Main extends Component {
             <h1 id="movie-name-heading">Remix</h1>
           </div>
           <div className="top-status" aria-label="Game status">
-            <span className="turn-pill">Turn {activeTeam + 1}</span>
+            <span className="turn-pill">{activeTeamName}</span>
             <button type="button" className="secondary-button score-toggle" onClick={this.openScorePopup}>{teams.map(team => team.score).join(' - ')}</button>
           </div>
         </header>
@@ -322,6 +340,7 @@ class Main extends Component {
             <div className="input-row">
               <input type="text"
                 id="movie-name"
+                placeholder="Enter a movie title"
                 name="movie_name"
                 value={this.state.movie_name}
                 onChange={e => {this.input_change(e)}}
@@ -337,15 +356,23 @@ class Main extends Component {
 
         <section className="clues-panel" aria-labelledby="clues-heading">
           <div className="section-heading">
-            <p className="eyebrow">Play words</p>
-            <h2 id="clues-heading">Clues</h2>
+            <div>
+              <p className="eyebrow">Play words</p>
+              <h2 id="clues-heading">Clue sets</h2>
+            </div>
+            {clueMovieName && <p className="clue-title">For <strong>{clueMovieName}</strong></p>}
           </div>
-          {syn_list ? <ul className="clue-list">{syn_list}</ul> : <p className="empty-state">Your generated clues will appear here.</p>}
+          {words.length > 0 && syn_list && (
+            <div className="source-words" aria-label="Movie title words">
+              {words.map((word, index) => <span key={`${word}-${index}`}>{word}</span>)}
+            </div>
+          )}
+          {syn_list ? <ul className="clue-list">{syn_list}</ul> : <p className="empty-state">Start typing a title to clear old clues. Search keeps existing clues visible until the new clue sets are ready.</p>}
         </section>
 
         <section className="timer-card compact-timer" aria-label="Round timer">
           <div>
-            <p className="eyebrow">{teams[activeTeam].name} guessing</p>
+            <p className="eyebrow">{activeTeamName} guessing</p>
             <p className="timer-display" aria-live="polite">{this.formatTime()}</p>
           </div>
           <div className="timer-controls">


### PR DESCRIPTION
### Motivation
- Make the active team clearer in the UI and improve the clue-words workflow so users understand when existing clues are preserved versus cleared while editing.
- Surface more context for generated clues so players can see which title produced the clue sets and which source words were used.

### Description
- Replace the numeric "Turn N" label with the active team name in the top bar and reuse that name in the timer area for clearer context.
- Clear existing clue rows immediately when the user edits the movie input, while keeping existing clues visible until a Search request completes and the new clue sets are ready.
- Add a placeholder to the movie input, show a "For <title>" clue title when clues are generated, display the source words as chips, and render numbered clue sets inside improved clue-card markup.
- Update CSS to support the new layout and styles for `.clue-title`, `.source-words`, `.clue-number`, and `.clue-phrase` to make clue cards more readable.

### Testing
- Ran unit tests with `npm test` which completed successfully (1 test passed).
- Built the production bundle with `npm run build` which completed successfully and produced the `dist` output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52949c5fa4832fb09ab7e1f24e6492)